### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:

--- a/src/util/rateLimits.ts
+++ b/src/util/rateLimits.ts
@@ -31,9 +31,12 @@ const postRateLimiter = new RateLimiterMemory({
 
 export const limitRequestRate: RequestHandler = catchErrors(async (req, res, next) => {
   try {
-    const limiter = req.method == 'GET' ? requestRateLimiter : postRateLimiter;
-    const limiterRes = await limiter.consume(req.ip);
-    setRateLimitHeaders(limiterRes, res);
+    // don't ratelimit login because it breaks integration tests and it has its own ratelimiters
+    if (req.path !== '/login') {
+      const limiter = req.method == 'GET' ? requestRateLimiter : postRateLimiter;
+      const limiterRes = await limiter.consume(req.ip);
+      setRateLimitHeaders(limiterRes, res);
+    }
     next();
   } catch (e) {
     if (e instanceof Error) {


### PR DESCRIPTION
Disables POST ratelimiting on the /login endpoint, which should resolve the constantly-failing-integration-tests issues. If not, then I'll have to make the ratelimiter be smarter/less restrictive for logged-in users.